### PR TITLE
Update build.rs

### DIFF
--- a/syntastica-parsers-git/build.rs
+++ b/syntastica-parsers-git/build.rs
@@ -126,9 +126,9 @@ fn compile_parser(
     let mut c_config = cc::Build::new();
     c_config.include(&src_dir);
     c_config
-        .flag("-Wno-unused-parameter")
-        .flag("-Wno-unused-but-set-variable")
-        .flag("-Wno-trigraphs")
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs")
         .flag_if_supported("-w");
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);


### PR DESCRIPTION
`no-unused-parameter` not supported on MSVC.
This makes it build for me.

Is there harm in making the rest conditional as well?