### PR TITLE
Add tree-sitter-ursa parser (WIP)

### DIFF
--- a/syntastica-macros/languages.toml
+++ b/syntastica-macros/languages.toml
@@ -694,6 +694,22 @@ injections = true
 locals = true
 
 [[languages]]
+name = "ursa"
+group = "all"
+file-types = ["ursa"]
+[languages.parser]
+git = { url = "https://github.com/ursalang/tree-sitter-ursa", rev = "62256e16d52c3df9bd791729c126ef313ce10069" }
+external-scanner = { c = true, cpp = false }
+ffi-func = "tree_sitter_ursa"
+rust-func = "language"
+package = "tree-sitter-ursa"
+# crates-io = ""
+[languages.queries]
+nvim-like = true
+injections = false
+locals = true
+
+[[languages]]
 name = "verilog"
 group = "all"
 file-types = ["verilog"]

--- a/syntastica-parsers/Cargo.toml
+++ b/syntastica-parsers/Cargo.toml
@@ -205,3 +205,7 @@ version = "=0.20.1"
 [dependencies.tree-sitter-toml]
 optional = true
 version = "=0.20.0"
+
+[dependencies.tree-sitter-ursa]
+optional = true
+version = "=0.0.3"

--- a/syntastica-parsers/README.md
+++ b/syntastica-parsers/README.md
@@ -73,6 +73,7 @@ for more information on all parser collections.
 - [ocaml_interface](https://docs.rs/tree-sitter-ocaml/0.20.4/)
 - [ql](https://github.com/tree-sitter/tree-sitter-ql) (not supported by this collection)
 - [rush](https://docs.rs/tree-sitter-rush/0.1.0/)
+- [ursa](https://docs.rs/tree-sitter-ursa/0.0.3/)
 - [verilog](https://github.com/tree-sitter/tree-sitter-verilog) (not supported by this collection)
 - [wat](https://github.com/wasm-lsp/tree-sitter-wasm) (not supported by this collection)
 

--- a/syntastica-queries/src/lib.rs
+++ b/syntastica-queries/src/lib.rs
@@ -296,6 +296,13 @@ pub const TYPESCRIPT_HIGHLIGHTS_CRATES_IO: &str = include_str!("../generated_que
 pub const TYPESCRIPT_INJECTIONS_CRATES_IO: &str = include_str!("../generated_queries/typescript/injections_crates_io.scm");
 pub const TYPESCRIPT_LOCALS_CRATES_IO: &str = include_str!("../generated_queries/typescript/locals_crates_io.scm");
 
+pub const URSA_HIGHLIGHTS: &str = include_str!("../generated_queries/ursa/highlights.scm");
+pub const URSA_INJECTIONS: &str = include_str!("../generated_queries/ursa/injections.scm");
+pub const URSA_LOCALS: &str = include_str!("../generated_queries/ursa/locals.scm");
+pub const URSA_HIGHLIGHTS_CRATES_IO: &str = include_str!("../generated_queries/ursa/highlights_crates_io.scm");
+pub const URSA_INJECTIONS_CRATES_IO: &str = include_str!("../generated_queries/ursa/injections_crates_io.scm");
+pub const URSA_LOCALS_CRATES_IO: &str = include_str!("../generated_queries/ursa/locals_crates_io.scm");
+
 pub const VERILOG_HIGHLIGHTS: &str = include_str!("../generated_queries/verilog/highlights.scm");
 pub const VERILOG_INJECTIONS: &str = include_str!("../generated_queries/verilog/injections.scm");
 pub const VERILOG_LOCALS: &str = include_str!("../generated_queries/verilog/locals.scm");


### PR DESCRIPTION
As you suggested, I attempted to start adding support for the (new) language I'm working on. As it's a published crate, I targeted `syntastica-parsers`.

I am not a Rust adept (I have dabbled a little), so I got stuck trying to find out where the build was failing and where else I need to mention my crate.